### PR TITLE
Added notifyReady event

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -34,6 +34,19 @@ Platform.init = function () {
 	});
 };
 
+Platform.prototype.notifyReady = function (callback) {
+	callback = callback || function () {
+		};
+
+	setImmediate(function () {
+		process.send({
+			type: 'ready'
+		});
+
+		callback();
+	});
+};
+
 Platform.prototype.log = function (title, description, callback) {
 	callback = callback || function () {
 		};


### PR DESCRIPTION
The plugin should call the notifyReady event in order to notify the
parent process that initialization is done.